### PR TITLE
Link WCAG references to specific guideline pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,10 @@
+# Agent Instructions
+
+When adding or updating references to WCAG success criteria:
+
+- Link to the specific guideline page on [WCAG.com](https://www.wcag.com/) rather than the homepage.
+- Use the corresponding developers or designers URL, for example:
+  - `https://www.wcag.com/developers/<slug>/`
+  - `https://www.wcag.com/designers/<slug>/`
+- If multiple success criteria are discussed together, include separate WCAG.com links for each.
 

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                 Structure is conveyed programmatically via landmarks, lists, and headings so AT can interpret relationships.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/info-and-relationships/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -99,7 +99,7 @@
                 All functionality is operable through a keyboard without specific timing. Our nav, toggler, and dropdowns are keyboard-usable.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/keyboard/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -117,7 +117,7 @@
                 Keyboard focus is not trapped in any component; users can move focus away using standard keys (Tab/Shift+Tab or Esc).
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#no-keyboard-trap" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/no-keyboard-trap/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -135,7 +135,7 @@
                 Provide a way to skip repeated content. We include a visible “Skip to main content” link that targets <code>#main-content</code>.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#bypass-blocks" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/bypass-blocks/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -153,7 +153,7 @@
                 Focus moves in a meaningful sequence that preserves relationships. DOM order: skip tray → header/nav → main → footer.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#focus-order" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/focus-order/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -171,7 +171,7 @@
                 Components expose their name, role, and state to assistive tech. Our dropdown trigger is a <code>button</code> with <code>aria-expanded</code> and <code>aria-controls</code>.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#name-role-value" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/name-role-value/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -190,7 +190,8 @@
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#reflow" target="_blank" rel="noopener">W3C Reflow</a> ·
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#text-spacing" target="_blank" rel="noopener">W3C Text Spacing</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/designers/reflow/" target="_blank" rel="noopener">WCAG.com Reflow</a> ·
+                  <a href="https://www.wcag.com/designers/text-spacing/" target="_blank" rel="noopener">WCAG.com Text Spacing</a>
                 </div>
               </div>
             </div>
@@ -208,7 +209,7 @@
                 Headings and labels describe topic or purpose. We use semantic headings and clear link text.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#headings-and-labels" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/designers/headings-and-labels/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -226,7 +227,7 @@
                 A visible focus indicator is present for keyboard focus. We add a high contrast outline with offset.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#focus-visible" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/focus-visible/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -250,7 +251,7 @@
                 When help mechanisms are present, they appear in a consistent location across pages. The footer contains stable contact/help links.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#consistent-help" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/wcag-2-2/" target="_blank" rel="noopener">WCAG.com 2.2</a>
+                  <a href="https://www.wcag.com/designers/consistent-help/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -268,7 +269,7 @@
                 Keyboard focus has a clearly visible indicator with sufficient contrast and area. We apply a 3px outline with offset to avoid being obscured.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-appearance" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/wcag-2-2/" target="_blank" rel="noopener">WCAG.com 2.2</a>
+                  <a href="https://www.wcag.com/designers/focus-appearance/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -287,7 +288,8 @@
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-minimum" target="_blank" rel="noopener">W3C Minimum</a> ·
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-enhanced" target="_blank" rel="noopener">W3C Enhanced</a> ·
-                  <a href="https://www.wcag.com/wcag-2-2/" target="_blank" rel="noopener">WCAG.com 2.2</a>
+                  <a href="https://www.wcag.com/developers/focus-not-obscured-minimum/" target="_blank" rel="noopener">WCAG.com Minimum</a> ·
+                  <a href="https://www.wcag.com/developers/focus-not-obscured-enhanced/" target="_blank" rel="noopener">WCAG.com Enhanced</a>
                 </div>
               </div>
             </div>
@@ -305,7 +307,7 @@
                 Pointer targets are at least <strong>24 by 24 CSS pixels</strong> or have equivalent spacing, with listed exceptions. Our interactive elements meet or exceed 24×24; 44×44 is used where comfortable.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#target-size-minimum" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/wcag-2-2/" target="_blank" rel="noopener">WCAG.com 2.2</a>
+                  <a href="https://www.wcag.com/designers/target-size-minimum/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -323,7 +325,7 @@
                 Motion triggered by interaction can be disabled unless essential. We respect <code>prefers-reduced-motion</code> and suppress transitions/animations accordingly.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#animation-from-interactions" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/wcag-2-2/" target="_blank" rel="noopener">WCAG.com 2.2</a>
+                  <a href="https://www.wcag.com/designers/animation-from-interactions/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace generic WCAG.com links with guideline-specific pages in the WCAG 2.1 and 2.2 references
- document linking expectations in AGENTS.md so future changes use precise WCAG.com URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7684c79f4832b9ca7d574fbcb9f37