### PR TITLE
Add color contrast guideline and fix WCAG link

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
       <section class="mt-4">
         <h2 class="h4">ADA &amp; WCAG Compliance</h2>
         <p>The Americans with Disabilities Act (ADA) and related laws treat <strong>WCAG 2.0 Level AA</strong> as a common legal baseline. Many organizations now adopt <strong>WCAG 2.1</strong> or <strong>2.2 Level AA</strong> as best practice to provide inclusive experiences and reduce legal risk.</p>
+        <ul class="mt-2">
+          <li><a href="https://www.ada.gov/" target="_blank" rel="noopener">Americans with Disabilities Act (ADA)</a></li>
+          <li><a href="https://www.section508.gov/" target="_blank" rel="noopener">Section 508 of the Rehabilitation Act</a></li>
+          <li><a href="https://eur-lex.europa.eu/eli/dir/2016/2102/oj" target="_blank" rel="noopener">EU Web Accessibility Directive (EN 301 549)</a></li>
+        </ul>
       </section>
 
       <!-- WCAG Reference: Accordions -->
@@ -82,6 +87,24 @@
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships" target="_blank" rel="noopener">W3C</a> ·
                   <a href="https://www.wcag.com/developers/info-and-relationships/" target="_blank" rel="noopener">WCAG.com</a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 1.4.3 -->
+          <div class="accordion-item">
+            <h3 class="accordion-header" id="h143">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c143" aria-expanded="false" aria-controls="c143">
+                1.4.3 Contrast (Minimum) <span class="badge bg-info ms-2">Level AA</span>
+              </button>
+            </h3>
+            <div id="c143" class="accordion-collapse collapse" aria-labelledby="h143" data-bs-parent="#wcag21">
+              <div class="accordion-body">
+                Text and interactive elements have a contrast ratio of at least <strong>4.5:1</strong> against adjacent colors to support users with low vision.
+                <div class="mt-2 small">
+                  <a href="https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum" target="_blank" rel="noopener">W3C</a> ·
+                  <a href="https://www.wcag.com/developers/1-4-3-contrast-minimum-level-aa/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>
@@ -307,7 +330,7 @@
                 Pointer targets are at least <strong>24 by 24 CSS pixels</strong> or have equivalent spacing, with listed exceptions. Our interactive elements meet or exceed 24×24; 44×44 is used where comfortable.
                 <div class="mt-2 small">
                   <a href="https://www.w3.org/WAI/WCAG22/quickref/#target-size-minimum" target="_blank" rel="noopener">W3C</a> ·
-                  <a href="https://www.wcag.com/designers/target-size-minimum/" target="_blank" rel="noopener">WCAG.com</a>
+                  <a href="https://www.wcag.com/developers/2-5-8-target-size-minimum-level-aa/" target="_blank" rel="noopener">WCAG.com</a>
                 </div>
               </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -27,6 +27,29 @@
   outline-offset: 2px;
 }
 
+/* Ensure text and link colors meet 1.4.3 Contrast (Minimum) */
+body {
+  background: #fff;
+  color: #212529;
+}
+
+a {
+  color: #0a58ca;
+}
+
+a:hover {
+  color: #06357a;
+}
+
+.navbar-dark .navbar-nav .nav-link {
+  color: #fff;
+}
+
+.navbar-dark .navbar-nav .nav-link:hover,
+.navbar-dark .navbar-nav .nav-link:focus {
+  color: #FFD54F;
+}
+
 /* Global focus ring for other controls (2.4.11 AA) */
 :root { --focus-ring: #FFD54F; }
 .navbar a:focus-visible,


### PR DESCRIPTION
## Summary
- ensure high contrast colors and navigation link visibility
- document compliance laws and reference WCAG 1.4.3
- correct WCAG.com link for Target Size Minimum

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b76b80e77c832b9aab707f391df248