### PR TITLE
Separate focus obscured criteria and align badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,13 @@
           <li><a href="https://www.section508.gov/" target="_blank" rel="noopener">Section 508 of the Rehabilitation Act</a></li>
           <li><a href="https://eur-lex.europa.eu/eli/dir/2016/2102/oj" target="_blank" rel="noopener">EU Web Accessibility Directive (EN 301 549)</a></li>
         </ul>
+        <p class="mt-3">WCAG references:</p>
+        <ul>
+          <li><a href="https://www.w3.org/TR/WCAG20/" target="_blank" rel="noopener">WCAG 2.0</a></li>
+          <li><a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noopener">WCAG 2.1</a></li>
+          <li><a href="https://www.w3.org/TR/WCAG22/" target="_blank" rel="noopener">WCAG 2.2</a></li>
+          <li><a href="https://www.w3.org/WAI/WCAG22/quickref/" target="_blank" rel="noopener">WCAG 2.2 Quick Reference</a></li>
+        </ul>
       </section>
 
       <!-- WCAG Reference: Accordions -->
@@ -298,25 +305,41 @@
             </div>
           </div>
 
-          <!-- 2.4.12 / 2.4.13 -->
-          <div class="accordion-item">
-            <h3 class="accordion-header" id="h2412">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c2412" aria-expanded="false" aria-controls="c2412">
-                2.4.12 Focus Not Obscured (Minimum) / 2.4.13 (Enhanced) <span class="badge bg-info ms-2">AA</span> <span class="badge bg-secondary ms-1">AAA</span>
-              </button>
-            </h3>
-            <div id="c2412" class="accordion-collapse collapse" aria-labelledby="h2412" data-bs-parent="#wcag22">
-              <div class="accordion-body">
-                The focused element is not fully hidden (AA) and ideally not hidden at all by author-created UI (AAA). We use outline offsets and <code>scroll-margin</code> on the main skip target.
-                <div class="mt-2 small">
-                  <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-minimum" target="_blank" rel="noopener">W3C Minimum</a> ·
-                  <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-enhanced" target="_blank" rel="noopener">W3C Enhanced</a> ·
-                  <a href="https://www.wcag.com/developers/focus-not-obscured-minimum/" target="_blank" rel="noopener">WCAG.com Minimum</a> ·
-                  <a href="https://www.wcag.com/developers/focus-not-obscured-enhanced/" target="_blank" rel="noopener">WCAG.com Enhanced</a>
+            <!-- 2.4.12 -->
+            <div class="accordion-item">
+              <h3 class="accordion-header" id="h2412">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c2412" aria-expanded="false" aria-controls="c2412">
+                  2.4.12 Focus Not Obscured (Minimum) <span class="badge bg-info">Level AA</span>
+                </button>
+              </h3>
+              <div id="c2412" class="accordion-collapse collapse" aria-labelledby="h2412" data-bs-parent="#wcag22">
+                <div class="accordion-body">
+                  The focused element is not fully hidden by author-created UI. We use outline offsets and <code>scroll-margin</code> on the main skip target.
+                  <div class="mt-2 small">
+                    <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-minimum" target="_blank" rel="noopener">W3C</a> ·
+                    <a href="https://www.wcag.com/developers/focus-not-obscured-minimum/" target="_blank" rel="noopener">WCAG.com</a>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+
+            <!-- 2.4.13 -->
+            <div class="accordion-item">
+              <h3 class="accordion-header" id="h2413">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c2413" aria-expanded="false" aria-controls="c2413">
+                  2.4.13 Focus Not Obscured (Enhanced) <span class="badge bg-secondary">Level AAA</span>
+                </button>
+              </h3>
+              <div id="c2413" class="accordion-collapse collapse" aria-labelledby="h2413" data-bs-parent="#wcag22">
+                <div class="accordion-body">
+                  The focused element is not hidden at all by author-created UI. We use outline offsets and <code>scroll-margin</code> on the main skip target.
+                  <div class="mt-2 small">
+                    <a href="https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-enhanced" target="_blank" rel="noopener">W3C</a> ·
+                    <a href="https://www.wcag.com/developers/focus-not-obscured-enhanced/" target="_blank" rel="noopener">WCAG.com</a>
+                  </div>
+                </div>
+              </div>
+            </div>
 
           <!-- 2.5.8 -->
           <div class="accordion-item">

--- a/style.css
+++ b/style.css
@@ -81,6 +81,23 @@ a:hover {
 /* Help make the skip target visible and not obscured */
 #main-content:focus { scroll-margin-top: 1rem; }
 
+/* Align accordion level badges to the right */
+.accordion-button {
+  position: relative;
+  padding-right: 4rem;
+}
+.accordion-button::after {
+  position: absolute;
+  right: 1rem;
+  margin-left: 0;
+}
+.accordion-button .badge {
+  position: absolute;
+  top: 50%;
+  right: 2.5rem;
+  transform: translateY(-50%);
+}
+
 /* Footer styles */
 .site-footer { color: #212529; }
 .footer-links .footer-link { text-decoration: none; }


### PR DESCRIPTION
## Summary
- add explicit WCAG 2.0/2.1/2.2 and quick reference links to compliance section
- split focus not obscured into distinct 2.4.12 and 2.4.13 accordion items with proper references
- align accordion level badges to the right for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7767bb660832bad0cc23ffcb99847